### PR TITLE
Fix Decimal summation when aggregating totals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+/.venv/
+/.pytest_cache/

--- a/Attempt_1/report_generator_attempt1.py
+++ b/Attempt_1/report_generator_attempt1.py
@@ -1,0 +1,21 @@
+"""Legacy attempt focused on Markdown output."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from report_generator import build_markdown_report, load_transactions, summarize_transactions
+
+
+def generate_markdown_report(input_path: str | Path, output_path: str | Path) -> Path:
+    """Generate a Markdown report using the original Attempt 1 workflow."""
+
+    input_path = Path(input_path)
+    output_path = Path(output_path)
+
+    transactions = load_transactions(input_path)
+    summary = summarize_transactions(transactions)
+    markdown = build_markdown_report(summary)
+
+    output_path.write_text(markdown, encoding="utf-8")
+    return output_path

--- a/Attempt_2/report_generator_attempt2.py
+++ b/Attempt_2/report_generator_attempt2.py
@@ -1,0 +1,21 @@
+"""Legacy attempt focused on HTML output."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from report_generator import build_html_report, load_transactions, summarize_transactions
+
+
+def generate_html_report(input_path: str | Path, output_path: str | Path) -> Path:
+    """Generate an HTML report using the Attempt 2 workflow."""
+
+    input_path = Path(input_path)
+    output_path = Path(output_path)
+
+    transactions = load_transactions(input_path)
+    summary = summarize_transactions(transactions)
+    html = build_html_report(summary)
+
+    output_path.write_text(html, encoding="utf-8")
+    return output_path

--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
-# Report_Generator
+# Report Generator
+
+This project merges the functionality explored in two previous prototypes
+(`Attempt_1` and `Attempt_2`) into a single, reusable Python package. The final
+implementation supports loading financial transactions from JSON or CSV files,
+calculating useful summaries, and rendering the result as Markdown, HTML, or
+JSON for downstream tooling.
+
+## Installation
+
+No external dependencies are required. The package only uses Python's standard
+library, so it can be executed with any recent Python 3.11+ interpreter.
+
+Clone the repository and install it in editable mode if desired:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+## Usage
+
+A sample dataset is provided in `data/sample_transactions.json`. Generate a
+report via the unified command-line interface:
+
+```bash
+python -m report_generator.cli data/sample_transactions.json --format html --output report.html
+```
+
+Use `--format markdown` (default) or `--format json` for alternative outputs.
+When the `--output` flag is omitted the report is written to standard output.
+
+The original attempt scripts remain available:
+
+- `Attempt_1/report_generator_attempt1.py` – produces Markdown output.
+- `Attempt_2/report_generator_attempt2.py` – produces HTML output.
+
+Both now delegate to the shared `report_generator` package so that bug fixes and
+feature additions apply consistently.

--- a/data/sample_transactions.json
+++ b/data/sample_transactions.json
@@ -1,0 +1,26 @@
+[
+  {
+    "date": "2025-01-02",
+    "category": "Sales",
+    "description": "Subscription renewal",
+    "amount": 249.99
+  },
+  {
+    "date": "2025-01-05",
+    "category": "Sales",
+    "description": "New customer",
+    "amount": 149.5
+  },
+  {
+    "date": "2025-01-05",
+    "category": "Refunds",
+    "description": "Refund to ACME Co.",
+    "amount": -49.99
+  },
+  {
+    "date": "2025-01-08",
+    "category": "Services",
+    "description": "Consulting engagement",
+    "amount": 1200
+  }
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "report-generator"
+version = "0.1.0"
+description = "Unified report generator combining two prototype attempts"
+readme = "README.md"
+authors = [{name = "Report Generator Maintainers"}]
+requires-python = ">=3.11"
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: OS Independent",
+]
+
+[project.urls]
+Homepage = "https://github.com/Jshatto/Report_Generator"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["report_generator"]

--- a/report_generator/__init__.py
+++ b/report_generator/__init__.py
@@ -1,0 +1,28 @@
+"""Merged report generator building on prior attempts."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from .data_sources import load_transactions
+from .models import ReportSummary, Transaction
+from .summary import summarize_transactions
+from .templates import build_html_report, build_markdown_report
+
+__all__ = [
+    "Transaction",
+    "ReportSummary",
+    "load_transactions",
+    "summarize_transactions",
+    "build_markdown_report",
+    "build_html_report",
+    "generate_report",
+]
+
+
+def generate_report(arguments: Iterable[str] | None = None) -> str:
+    """Delegate to :mod:`report_generator.cli` without creating import loops."""
+
+    from .cli import generate_report as _generate_report
+
+    return _generate_report(arguments)

--- a/report_generator/cli.py
+++ b/report_generator/cli.py
@@ -1,0 +1,74 @@
+"""Command line entry point combining the previous attempts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Iterable
+
+from .data_sources import load_transactions
+from .summary import summarize_transactions
+from .templates import build_html_report, build_markdown_report
+
+
+def build_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Generate financial reports")
+    parser.add_argument(
+        "input",
+        type=Path,
+        help="Path to a JSON or CSV file containing transaction data",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=None,
+        help="Destination file. If omitted the report is printed to stdout.",
+    )
+    parser.add_argument(
+        "-f",
+        "--format",
+        choices=("markdown", "html", "json"),
+        default="markdown",
+        help="Output format for the generated report",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Pretty print JSON output",
+    )
+    return parser
+
+
+def generate_report(arguments: Iterable[str] | None = None) -> str:
+    parser = build_argument_parser()
+    args = parser.parse_args(arguments)
+
+    transactions = load_transactions(args.input)
+    summary = summarize_transactions(transactions)
+
+    match args.format:
+        case "markdown":
+            rendered = build_markdown_report(summary)
+        case "html":
+            rendered = build_html_report(summary)
+        case "json":
+            rendered = json.dumps(summary.as_dict(), indent=2 if args.pretty else None)
+        case _ as unreachable:  # pragma: no cover - safeguarded by argparse
+            raise ValueError(unreachable)
+
+    if args.output:
+        args.output.write_text(rendered, encoding="utf-8")
+        return str(args.output)
+
+    print(rendered)
+    return ""
+
+
+def main() -> None:  # pragma: no cover - thin wrapper
+    generate_report()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/report_generator/data_sources.py
+++ b/report_generator/data_sources.py
@@ -1,0 +1,106 @@
+"""Utilities for loading transaction data from disk."""
+
+from __future__ import annotations
+
+from csv import DictReader
+from datetime import date
+from decimal import Decimal
+import json
+from pathlib import Path
+from typing import Iterable
+
+from .models import Transaction
+
+SUPPORTED_EXTENSIONS = {".json", ".csv"}
+
+
+def _normalise_category(value: str) -> str:
+    return value.strip() or "Uncategorised"
+
+
+def load_transactions(path: Path) -> list[Transaction]:
+    """Load transaction data from ``path``.
+
+    Parameters
+    ----------
+    path:
+        A JSON or CSV file containing rows with the keys ``date``, ``category``,
+        ``description`` and ``amount``.
+    """
+
+    if not path.exists():
+        msg = f"No such input file: {path}"
+        raise FileNotFoundError(msg)
+
+    suffix = path.suffix.lower()
+    if suffix not in SUPPORTED_EXTENSIONS:
+        msg = f"Unsupported file type: {suffix}. Supported: {sorted(SUPPORTED_EXTENSIONS)}"
+        raise ValueError(msg)
+
+    if suffix == ".json":
+        transactions = _load_json(path)
+    else:
+        transactions = _load_csv(path)
+
+    return [Transaction.from_mapping(txn) for txn in transactions]
+
+
+def _load_json(path: Path) -> Iterable[dict[str, object]]:
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+
+    if not isinstance(payload, list):
+        msg = "JSON input must be a list of mappings"
+        raise ValueError(msg)
+
+    for raw in payload:
+        yield {
+            "date": _coerce_date(raw, "date"),
+            "category": _normalise_category(str(raw.get("category", ""))),
+            "description": str(raw.get("description", "")),
+            "amount": _coerce_amount(raw, "amount"),
+        }
+
+
+def _load_csv(path: Path) -> Iterable[dict[str, object]]:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        reader = DictReader(handle)
+        for row in reader:
+            yield {
+                "date": _coerce_date(row, "date"),
+                "category": _normalise_category(row.get("category", "")),
+                "description": row.get("description", ""),
+                "amount": _coerce_amount(row, "amount"),
+            }
+
+
+def _coerce_date(mapping: dict[str, object], key: str) -> date:
+    raw_value = mapping.get(key)
+    if raw_value is None:
+        msg = f"Missing '{key}' field"
+        raise ValueError(msg)
+
+    if isinstance(raw_value, date):
+        return raw_value
+
+    if isinstance(raw_value, str):
+        return date.fromisoformat(raw_value.strip())
+
+    msg = f"Unable to parse date value: {raw_value!r}"
+    raise ValueError(msg)
+
+
+def _coerce_amount(mapping: dict[str, object], key: str) -> Decimal:
+    raw_value = mapping.get(key)
+    if raw_value is None:
+        msg = f"Missing '{key}' field"
+        raise ValueError(msg)
+
+    if isinstance(raw_value, Decimal):
+        return raw_value
+
+    if isinstance(raw_value, (int, float, str)):
+        return Decimal(str(raw_value))
+
+    msg = f"Unable to parse numeric value: {raw_value!r}"
+    raise ValueError(msg)

--- a/report_generator/models.py
+++ b/report_generator/models.py
@@ -1,0 +1,101 @@
+"""Data models used across the report generator package."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from typing import Iterable, Mapping
+
+
+@dataclass(frozen=True, slots=True)
+class Transaction:
+    """Represents a single financial transaction."""
+
+    occurred_on: date
+    category: str
+    description: str
+    amount: Decimal
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, object]) -> "Transaction":
+        """Create a :class:`Transaction` from a mapping of basic Python types.
+
+        Parameters
+        ----------
+        data:
+            A mapping that must contain the keys ``date``, ``category``,
+            ``description`` and ``amount``. The ``date`` value can either be a
+            :class:`datetime.date` or an ISO formatted string (``YYYY-MM-DD``).
+
+        Returns
+        -------
+        Transaction
+            A populated dataclass ready to be used throughout the report
+            generator.
+        """
+
+        raw_date = data["date"]
+        if isinstance(raw_date, date):
+            occurred_on = raw_date
+        elif isinstance(raw_date, str):
+            occurred_on = date.fromisoformat(raw_date)
+        else:
+            msg = "Unsupported date value in transaction mapping"
+            raise TypeError(msg)
+
+        amount = data["amount"]
+        if isinstance(amount, Decimal):
+            amount_value = amount
+        elif isinstance(amount, (int, float, str)):
+            amount_value = Decimal(str(amount))
+        else:
+            msg = "Unsupported amount value in transaction mapping"
+            raise TypeError(msg)
+
+        return cls(
+            occurred_on=occurred_on,
+            category=str(data["category"]),
+            description=str(data["description"]),
+            amount=amount_value,
+        )
+
+
+@dataclass(slots=True)
+class ReportSummary:
+    """A lightweight container for all derived report information."""
+
+    transactions: list[Transaction]
+    total_amount: Decimal
+    totals_by_category: dict[str, Decimal]
+    totals_by_day: dict[date, Decimal]
+
+    def as_dict(self) -> dict[str, object]:
+        """Return a JSON serialisable representation of the summary."""
+
+        return {
+            "transactions": [
+                {
+                    "date": transaction.occurred_on.isoformat(),
+                    "category": transaction.category,
+                    "description": transaction.description,
+                    "amount": str(transaction.amount),
+                }
+                for transaction in self.transactions
+            ],
+            "total_amount": str(self.total_amount),
+            "totals_by_category": {
+                category: str(total)
+                for category, total in sorted(self.totals_by_category.items())
+            },
+            "totals_by_day": {
+                day.isoformat(): str(total)
+                for day, total in sorted(self.totals_by_day.items())
+            },
+        }
+
+    def __bool__(self) -> bool:  # pragma: no cover - convenience method
+        return bool(self.transactions)
+
+
+IterableTransactions = Iterable[Transaction]

--- a/report_generator/summary.py
+++ b/report_generator/summary.py
@@ -1,0 +1,39 @@
+"""Business logic for deriving insights from raw transactions."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import date
+from decimal import Decimal
+from typing import Iterable
+
+from .models import ReportSummary, Transaction
+
+
+def summarize_transactions(transactions: Iterable[Transaction]) -> ReportSummary:
+    """Calculate totals from the supplied transactions."""
+
+    transactions = list(transactions)
+    if not transactions:
+        return ReportSummary(
+            transactions=[],
+            total_amount=Decimal("0"),
+            totals_by_category={},
+            totals_by_day={},
+        )
+
+    total_amount = sum((txn.amount for txn in transactions), Decimal("0"))
+
+    totals_by_category: dict[str, Decimal] = defaultdict(lambda: Decimal("0"))
+    totals_by_day: dict[date, Decimal] = defaultdict(lambda: Decimal("0"))
+
+    for txn in transactions:
+        totals_by_category[txn.category] += txn.amount
+        totals_by_day[txn.occurred_on] += txn.amount
+
+    return ReportSummary(
+        transactions=transactions,
+        total_amount=total_amount,
+        totals_by_category=dict(sorted(totals_by_category.items())),
+        totals_by_day=dict(sorted(totals_by_day.items())),
+    )

--- a/report_generator/templates.py
+++ b/report_generator/templates.py
@@ -1,0 +1,161 @@
+"""Rendering helpers for human-friendly report outputs."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from textwrap import indent
+
+from .models import ReportSummary
+
+
+def build_markdown_report(summary: ReportSummary) -> str:
+    """Render the report as Markdown."""
+
+    lines = ["# Financial Summary", ""]
+
+    if not summary.transactions:
+        lines.append("No transactions supplied.")
+        return "\n".join(lines)
+
+    lines.extend(_render_overview(summary))
+    lines.append("")
+    lines.extend(_render_category_table(summary))
+    lines.append("")
+    lines.extend(_render_daily_totals(summary))
+    lines.append("")
+    lines.append("## Transactions")
+    lines.append("")
+    lines.append("| Date | Category | Description | Amount |")
+    lines.append("| --- | --- | --- | ---: |")
+    for txn in summary.transactions:
+        lines.append(
+            f"| {txn.occurred_on.isoformat()} | {txn.category} | "
+            f"{txn.description} | ${txn.amount:.2f} |"
+        )
+
+    return "\n".join(lines)
+
+
+def build_html_report(summary: ReportSummary) -> str:
+    """Render the report as a standalone HTML string."""
+
+    if not summary.transactions:
+        body = "<p>No transactions supplied.</p>"
+    else:
+        body = "\n".join(
+            [
+                "<section>",
+                indent("\n".join(_render_overview(summary, html=True)), "  "),
+                "</section>",
+                "<section>",
+                indent(_render_category_table(summary, html=True), "  "),
+                "</section>",
+                "<section>",
+                indent(_render_daily_totals(summary, html=True), "  "),
+                "</section>",
+                "<section>",
+                indent(_render_transaction_table(summary), "  "),
+                "</section>",
+            ]
+        )
+
+    return (
+        "<!DOCTYPE html>\n"
+        "<html lang=\"en\">\n"
+        "<head>\n"
+        "  <meta charset=\"utf-8\">\n"
+        "  <title>Financial Summary</title>\n"
+        "  <style>\n"
+        "    body { font-family: sans-serif; margin: 2rem; }\n"
+        "    table { border-collapse: collapse; width: 100%; margin-top: 1rem; }\n"
+        "    th, td { border: 1px solid #ccc; padding: 0.5rem; text-align: left; }\n"
+        "    th { background: #f3f4f6; }\n"
+        "    td:last-child, th:last-child { text-align: right; }\n"
+        "    section { margin-bottom: 2rem; }\n"
+        "  </style>\n"
+        "</head>\n"
+        "<body>\n"
+        "<h1>Financial Summary</h1>\n"
+        f"{body}\n"
+        "</body>\n"
+        "</html>\n"
+    )
+
+
+def _render_overview(summary: ReportSummary, *, html: bool = False) -> list[str]:
+    lines = ["## Overview" if not html else "<h2>Overview</h2>"]
+
+    total = f"${summary.total_amount:.2f}"
+    if html:
+        lines.append(f"<p>Total amount: <strong>{total}</strong></p>")
+    else:
+        lines.append(f"Total amount: **{total}**")
+
+    return lines
+
+
+def _render_category_table(summary: ReportSummary, *, html: bool = False) -> list[str] | str:
+    if html:
+        rows = "\n".join(
+            f"    <tr><td>{category}</td><td>${total:.2f}</td></tr>"
+            for category, total in summary.totals_by_category.items()
+        )
+        return (
+            "<h2>Totals by category</h2>\n"
+            "<table>\n"
+            "  <thead><tr><th>Category</th><th>Total</th></tr></thead>\n"
+            "  <tbody>\n"
+            f"{rows}\n"
+            "  </tbody>\n"
+            "</table>"
+        )
+
+    lines = ["## Totals by category", "", "| Category | Total |", "| --- | ---: |"]
+    for category, total in summary.totals_by_category.items():
+        lines.append(f"| {category} | ${total:.2f} |")
+    return lines
+
+
+def _render_daily_totals(summary: ReportSummary, *, html: bool = False) -> list[str] | str:
+    if html:
+        rows = "\n".join(
+            f"    <tr><td>{day.isoformat()}</td><td>${total:.2f}</td></tr>"
+            for day, total in summary.totals_by_day.items()
+        )
+        return (
+            "<h2>Totals by day</h2>\n"
+            "<table>\n"
+            "  <thead><tr><th>Date</th><th>Total</th></tr></thead>\n"
+            "  <tbody>\n"
+            f"{rows}\n"
+            "  </tbody>\n"
+            "</table>"
+        )
+
+    lines = ["## Totals by day", "", "| Date | Total |", "| --- | ---: |"]
+    for day, total in summary.totals_by_day.items():
+        lines.append(f"| {day.isoformat()} | ${total:.2f} |")
+    return lines
+
+
+def _render_transaction_table(summary: ReportSummary) -> str:
+    rows = "\n".join(
+        "    <tr>"
+        f"<td>{txn.occurred_on.isoformat()}</td>"
+        f"<td>{txn.category}</td>"
+        f"<td>{txn.description}</td>"
+        f"<td>${txn.amount:.2f}</td>"
+        "</tr>"
+        for txn in summary.transactions
+    )
+
+    return (
+        "<h2>Transactions</h2>\n"
+        "<table>\n"
+        "  <thead><tr><th>Date</th><th>Category</th><th>Description</th><th>Amount</th></tr></thead>\n"
+        "  <tbody>\n"
+        f"{rows}\n"
+        "  </tbody>\n"
+        "</table>"
+    )


### PR DESCRIPTION
## Summary
- consolidate the legacy Attempt_1 and Attempt_2 scripts onto a shared `report_generator` package
- add loaders, summarisation logic, and Markdown/HTML/JSON rendering helpers for transaction reports
- provide a CLI entry point, packaging metadata, sample data, and documentation for generating reports
- fix the Decimal aggregation in `summarize_transactions` so totals are computed without raising `TypeError`

## Testing
- `python -m report_generator.cli data/sample_transactions.json --format json --pretty`
- `python -m report_generator.cli data/sample_transactions.json --format html --output /tmp/report.html`


------
https://chatgpt.com/codex/tasks/task_e_68da99ae01c0832bafada86e515ce8ef